### PR TITLE
feat: support JSON upload output

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ $ gh share --open pr123.html
 
 # Keep the staging branch after the upload
 $ gh share --persist pr123.html
+
+# Output upload details as JSON
+$ gh share --json pr123.html
 ```
 
 The primary use case is sharing a single-page HTML file. The command also supports arbitrary files and directories.
@@ -85,6 +88,7 @@ The staging branch is based on the repository's default branch, so the GitHub AP
 | `--branch` | Staging branch name. Defaults to `gh-share-staging`. |
 | `--open` | Open the artifact URL in the browser after the upload completes. |
 | `--persist` | Keep the staging branch after the upload. |
+| `--json` | Output upload details as JSON. |
 
 ## Installation
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ import (
 const defaultBranch = "gh-share-staging"
 
 var shareRepo, shareBranch string
-var shareOpen, sharePersist bool
+var shareOpen, sharePersist, shareJSON bool
 
 var rootCmd = func() *cobra.Command {
 	cmd := newShareCommand()
@@ -55,6 +55,7 @@ gh-share creates a temporary staging branch, commits the payload and an upload w
 	cmd.Flags().StringVar(&shareBranch, "branch", defaultBranch, "Staging branch name")
 	cmd.Flags().BoolVar(&shareOpen, "open", false, "Open the artifact URL in the browser")
 	cmd.Flags().BoolVar(&sharePersist, "persist", false, "Keep the staging branch after upload")
+	cmd.Flags().BoolVar(&shareJSON, "json", false, "Output upload details as JSON")
 	return cmd
 }
 
@@ -145,9 +146,37 @@ func share(ctx context.Context, input string) error {
 	if info.IsDir() {
 		uploadMessage = fmt.Sprintf("Successfully uploaded directory: %s", inputName)
 	}
-	s.FinalMSG = "\n" + uploadMessage + "\n\n" + formatSummary(branchURL, branchStatus, commitURL, runURL) + formatArtifactURL(url)
+	result := shareResult{
+		Input:         inputName,
+		InputType:     kind,
+		Repository:    fmt.Sprintf("https://github.com/%s/%s", owner, repo),
+		Branch:        branchURL,
+		BranchDeleted: !keep,
+		Commit:        commitURL,
+		Workflow:      runURL,
+		Artifact:      url,
+	}
+	if !shareJSON {
+		s.FinalMSG = "\n" + uploadMessage + "\n\n" + formatSummary(branchURL, branchStatus, commitURL, runURL) + formatArtifactURL(url)
+	}
 	s.Stop()
+	if shareJSON {
+		if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+			return fmt.Errorf("encode JSON output: %w", err)
+		}
+	}
 	return nil
+}
+
+type shareResult struct {
+	Input         string `json:"input"`
+	InputType     string `json:"input_type"`
+	Repository    string `json:"repository"`
+	Branch        string `json:"branch"`
+	BranchDeleted bool   `json:"branch_deleted"`
+	Commit        string `json:"commit"`
+	Workflow      string `json:"workflow"`
+	Artifact      string `json:"artifact"`
 }
 
 func formatSummary(branchURL, branchStatus, commitURL, runURL string) string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -161,7 +161,9 @@ func share(ctx context.Context, input string) error {
 	}
 	s.Stop()
 	if shareJSON {
-		if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(result); err != nil {
 			return fmt.Errorf("encode JSON output: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary

Add a machine-readable output mode for integrations while preserving the human-readable progress display for normal use.

## Changes

- add the --json option to output upload details as JSON
- keep spinner and progress messages on stderr
- include repository, branch, commit, workflow, and artifact information
- expose branch cleanup as the boolean branch_deleted field
- document the option in the README
