### PR TITLE
fix: use input name for artifact

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,7 +90,7 @@ func share(ctx context.Context, input string) error {
 	if info.IsDir() {
 		kind = "dir"
 	}
-	files[".gh-share-payload-ref"] = []byte(ts + " " + kind + "\n")
+	files[".gh-share-payload-ref"] = []byte(ts + " " + kind + " " + filepath.Base(filepath.Clean(input)) + "\n")
 	if sharePersist && !marker {
 		files[".gh-share-persist"] = []byte("\n")
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -47,7 +47,7 @@ func TestGitHubAPIEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create payload: %v", err)
 	}
-	files[".gh-share-payload-ref"] = []byte(ts + " file\n")
+	files[".gh-share-payload-ref"] = []byte(ts + " file report.html\n")
 
 	sha, err := commitPayload(ctx, c, owner, repo, branch, files, func(string) {})
 	if err != nil {
@@ -79,6 +79,13 @@ func TestGitHubAPIEndToEnd(t *testing.T) {
 	}
 	if !strings.Contains(artifact, fmt.Sprintf("/runs/%d/artifacts/", run.GetID())) {
 		t.Fatalf("artifact URL = %q, want run ID %d", artifact, run.GetID())
+	}
+	artifacts, _, err := c.Actions.ListWorkflowRunArtifacts(ctx, owner, repo, run.GetID(), nil)
+	if err != nil {
+		t.Fatalf("list artifacts: %v", err)
+	}
+	if len(artifacts.Artifacts) != 1 || artifacts.Artifacts[0].GetName() != "report.html" {
+		t.Fatalf("artifact name = %#v, want report.html", artifacts.Artifacts)
 	}
 }
 

--- a/cmd/upload-gh-share-payload.yml
+++ b/cmd/upload-gh-share-payload.yml
@@ -15,21 +15,21 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Read payload ref
         run: |
-          PAYLOAD_DIR=$(awk '{print $1}' .gh-share-payload-ref)
-          PAYLOAD_TYPE=$(awk '{print $2}' .gh-share-payload-ref)
+          read -r PAYLOAD_DIR PAYLOAD_TYPE PAYLOAD_NAME < .gh-share-payload-ref
           echo "PAYLOAD_DIR=$PAYLOAD_DIR" >> "$GITHUB_ENV"
           echo "PAYLOAD_TYPE=$PAYLOAD_TYPE" >> "$GITHUB_ENV"
+          echo "PAYLOAD_NAME=$PAYLOAD_NAME" >> "$GITHUB_ENV"
       - name: Upload (file)
         if: env.PAYLOAD_TYPE == 'file'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ github.sha }}
+          name: ${{ env.PAYLOAD_NAME }}
           path: gh-share-payload/${{ env.PAYLOAD_DIR }}/
           archive: false
       - name: Upload (dir)
         if: env.PAYLOAD_TYPE == 'dir'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ github.sha }}
+          name: ${{ env.PAYLOAD_NAME }}
           path: gh-share-payload/${{ env.PAYLOAD_DIR }}/
           archive: true


### PR DESCRIPTION
## Summary

Make uploaded artifacts identifiable by using the input file or directory name instead of the commit SHA.

## Changes

- store the input basename in the existing .gh-share-payload-ref metadata
- use the stored name for directory artifact uploads
- verify the artifact name in the GitHub API end-to-end test
