### PR TITLE
fix: preserve persistent branches during purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The staging branch is based on the repository's default branch, so the GitHub AP
 | `--json` | Output upload details as JSON. |
 | `--purge` | Delete gh-share workflow runs, artifacts, and staging branches instead of uploading. |
 
-`--purge` removes all completed runs of the embedded gh-share workflow in the target repository. The associated artifacts and logs are removed with the runs, and branches used by those runs are deleted except for the repository's default branch. Artifact URLs from the deleted runs will no longer work.
+`--purge` removes all completed runs of the embedded gh-share workflow in the target repository. The associated artifacts and logs are removed with the runs, and branches used by those runs are deleted except for the repository's default branch and branches containing `.gh-share-persist`. Artifact URLs from the deleted runs will no longer work.
 
 ## Installation
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,6 +130,13 @@ func purge(ctx context.Context) error {
 		if branch == repositoryInfo.GetDefaultBranch() {
 			continue
 		}
+		persist, err := hasPersistMarker(ctx, c, owner, repo, branch)
+		if err != nil {
+			return fmt.Errorf("check persist marker for staging branch %s: %w", branch, err)
+		}
+		if persist {
+			continue
+		}
 		if _, err := c.Git.DeleteRef(ctx, owner, repo, "heads/"+branch); err != nil {
 			var apiErr *github.ErrorResponse
 			if errors.As(err, &apiErr) && (apiErr.Response.StatusCode == 404 || apiErr.Message == "Reference does not exist") {


### PR DESCRIPTION
## Summary

Keep intentionally persistent gh-share branches when purging temporary workflow history, and require confirmation before the destructive cleanup starts.

## Changes

- check `.gh-share-persist` before deleting each staging branch
- preserve marked branches while still deleting their completed workflow runs and associated artifacts and logs
- tolerate staging branches that were already deleted
- prompt for confirmation before deleting workflow history
- document the persistent-branch and confirmation behavior