### PR TITLE
feat: confirm purge before deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The staging branch is based on the repository's default branch, so the GitHub AP
 | `--json` | Output upload details as JSON. |
 | `--purge` | Delete gh-share workflow runs, artifacts, and staging branches instead of uploading. |
 
-`--purge` removes all completed runs of the embedded gh-share workflow in the target repository. The associated artifacts and logs are removed with the runs, and branches used by those runs are deleted except for the repository's default branch and branches containing `.gh-share-persist`. Artifact URLs from the deleted runs will no longer work.
+`--purge` asks for confirmation before removing all completed runs of the embedded gh-share workflow in the target repository. The associated artifacts and logs are removed with the runs, and branches used by those runs are deleted except for the repository's default branch and branches containing `.gh-share-persist`. Artifact URLs from the deleted runs will no longer work.
 
 ## Installation
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -188,7 +188,7 @@ func confirmPurge(in io.Reader, out io.Writer, owner, repo string, workflowRuns,
 	}
 	answer = strings.ToLower(strings.TrimSpace(answer))
 	if answer != "y" && answer != "yes" {
-		fmt.Fprintln(out, "Purge cancelled.")
+		fmt.Fprintln(out, "Purge canceled.")
 		return false, nil
 	}
 	return true, nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -61,7 +63,7 @@ Use --purge without an input path to delete gh-share workflow runs, their artifa
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if sharePurge {
-				return purge(cmd.Context())
+				return purge(cmd.Context(), cmd.InOrStdin(), cmd.ErrOrStderr())
 			}
 			return share(cmd.Context(), args[0])
 		},
@@ -75,7 +77,7 @@ Use --purge without an input path to delete gh-share workflow runs, their artifa
 	return cmd
 }
 
-func purge(ctx context.Context) error {
+func purge(ctx context.Context, in io.Reader, out io.Writer) error {
 	owner, repo, err := repository(ctx, shareRepo)
 	if err != nil {
 		return err
@@ -114,6 +116,26 @@ func purge(ctx context.Context) error {
 		if branch := run.GetHeadBranch(); branch != "" {
 			branches[branch] = struct{}{}
 		}
+	}
+	if len(runs) == 0 {
+		if shareJSON {
+			return json.NewEncoder(os.Stdout).Encode(struct {
+				WorkflowRuns    int `json:"workflow_runs_deleted"`
+				StagingBranches int `json:"staging_branches_deleted"`
+			}{})
+		}
+		fmt.Fprintf(out, "No gh-share workflow runs found in %s/%s.\n", owner, repo)
+		return nil
+	}
+	if ok, err := confirmPurge(in, out, owner, repo, len(runs), len(branches)); err != nil {
+		return err
+	} else if !ok {
+		if shareJSON {
+			return json.NewEncoder(os.Stdout).Encode(struct {
+				Purged bool `json:"purged"`
+			}{false})
+		}
+		return nil
 	}
 	for _, run := range runs {
 		if _, err := c.Actions.DeleteWorkflowRun(ctx, owner, repo, run.GetID()); err != nil {
@@ -156,6 +178,20 @@ func purge(ctx context.Context) error {
 	}
 	fmt.Fprintf(os.Stderr, "Purged %d gh-share workflow run(s) and %d staging branch(es) from %s/%s.\n", len(runs), deletedBranches, owner, repo)
 	return nil
+}
+
+func confirmPurge(in io.Reader, out io.Writer, owner, repo string, workflowRuns, branches int) (bool, error) {
+	fmt.Fprintf(out, "Purge %d gh-share workflow run(s) and up to %d staging branch(es) from %s/%s? [y/N] ", workflowRuns, branches, owner, repo)
+	answer, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, fmt.Errorf("read purge confirmation: %w", err)
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	if answer != "y" && answer != "yes" {
+		fmt.Fprintln(out, "Purge cancelled.")
+		return false, nil
+	}
+	return true, nil
 }
 
 func share(ctx context.Context, input string) error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -152,5 +153,33 @@ func TestFormatSummary(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("formatSummary() does not contain %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestConfirmPurge(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	ok, err := confirmPurge(strings.NewReader("yes\n"), &out, "k1LoW", "gh-share", 2, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("confirmPurge() = false, want true")
+	}
+	if !strings.Contains(out.String(), "Purge 2 gh-share workflow run(s)") {
+		t.Fatalf("confirmation prompt = %q", out.String())
+	}
+
+	out.Reset()
+	ok, err = confirmPurge(strings.NewReader("n\n"), &out, "k1LoW", "gh-share", 2, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("confirmPurge() = true, want false")
+	}
+	if !strings.Contains(out.String(), "Purge cancelled.") {
+		t.Fatalf("cancellation output = %q", out.String())
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -179,7 +179,7 @@ func TestConfirmPurge(t *testing.T) {
 	if ok {
 		t.Fatal("confirmPurge() = true, want false")
 	}
-	if !strings.Contains(out.String(), "Purge cancelled.") {
+	if !strings.Contains(out.String(), "Purge canceled.") {
 		t.Fatalf("cancellation output = %q", out.String())
 	}
 }


### PR DESCRIPTION
## Summary

Require confirmation before the destructive purge mode removes gh-share workflow history and artifacts.

## Changes

- prompt before deleting workflow runs and staging branches
- accept only `y` or `yes` and cancel by default
- keep prompts on stderr so `--json` output remains machine-readable
- add confirmation tests and document the behavior