### PR TITLE
feat!: record shared artifacts under the new .gh-share/ layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 	go test ./... -coverprofile=coverage.out -covermode=count -count=1
 
 e2e:
-	GH_SHARE_E2E=1 go test ./cmd -run '^TestGitHubAPIEndToEnd$$' -count=1 -v
+	GH_SHARE_E2E=1 go test ./cmd -run '^TestGitHubAPIEndToEnd' -count=1 -v
 
 lint:
 	golangci-lint run ./...

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The staging branch is based on the repository's default branch, so the GitHub AP
 | `--json` | Output upload details as JSON. |
 | `--purge` | Delete gh-share workflow runs, artifacts, and staging branches instead of uploading. |
 
-`--purge` asks for confirmation before removing all completed runs of the embedded gh-share workflow in the target repository. The associated artifacts and logs are removed with the runs, and branches used by those runs are deleted except for the repository's default branch and branches containing `.gh-share/persist`. Artifact URLs from the deleted runs will no longer work.
+`--purge` asks for confirmation before removing all completed runs of the embedded gh-share workflow in the target repository. The associated artifacts and logs are removed with the runs, and branches used by those runs are deleted except for the repository's default branch and branches containing `.gh-share/persist`. The `.gh-share-persist` marker written before the `.gh-share/` layout still counts as one, so branches persisted by an earlier version are kept as well. Artifact URLs from the deleted runs will no longer work.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,18 @@ The primary use case is sharing a single-page HTML file. The command also suppor
 
 The command displays progress while it creates the staging branch, creates the commit, waits for the workflow, and removes or keeps the branch. The final output includes links to the staging branch, commit, workflow run, and artifact.
 
-For a file, the artifact contains the file under `gh-share-payload/<timestamp>/`. For a directory, the directory contents are uploaded as one artifact.
+For a file, the artifact contains the file under `.gh-share/payloads/<timestamp>/`. For a directory, the directory contents are uploaded as one artifact.
+
+## Staging branch layout
+
+Everything gh-share writes to the staging branch lives under `.gh-share/`, apart from the workflow that GitHub requires under `.github/workflows/`.
+
+```
+.gh-share/
+  payload-ref                   # the workflow's only trigger path
+  persist                       # present when --persist was used
+  payloads/<timestamp>/         # the uploaded payload
+```
 
 ## How it works
 
@@ -68,8 +79,8 @@ The process is:
 1. Resolve the target repository with `gh repo view`.
 2. Check whether the staging branch exists. If it does not, create it from the repository's default branch.
 3. Create Git blobs for the payload and build the required tree structure through the GitHub Git Database API.
-4. Add `.gh-share-payload-ref` and the embedded `.github/workflows/upload-gh-share-payload.yml` workflow, then create one commit containing all of them.
-5. Update the staging branch to that commit. The push triggers the workflow because the payload paths changed.
+4. Add `.gh-share/payload-ref` and the embedded `.github/workflows/upload-gh-share-payload.yml` workflow, then create one commit containing all of them.
+5. Update the staging branch to that commit. The push triggers the workflow because `.gh-share/payload-ref` changed.
 6. Poll GitHub Actions until the workflow completes and resolve the artifact URL.
 7. Delete the staging branch, unless persistence was requested or the branch already contains the persistence marker.
 
@@ -79,7 +90,9 @@ GitHub Actions can only run a workflow that exists in the commit that triggered 
 
 The extension uses the Git Database API directly to create blobs, trees, commits, and refs. A single commit is important here: it gives the workflow one unambiguous commit SHA to monitor and avoids triggering the workflow multiple times during one upload.
 
-The workflow reads `.gh-share-payload-ref` to find the timestamped payload directory and determine whether the input was a file or directory. It then uploads that directory with `actions/upload-artifact`.
+The workflow reads `.gh-share/payload-ref` to find the timestamped payload directory and determine whether the input was a file or directory. It then uploads that directory with `actions/upload-artifact`.
+
+Only `.gh-share/payload-ref` triggers the workflow. Every share rewrites it with a new timestamp, so listing the payload directory as a trigger path as well would be redundant.
 
 The staging branch is based on the repository's default branch, so the GitHub API can build a valid commit without cloning or modifying the local repository.
 
@@ -94,7 +107,7 @@ The staging branch is based on the repository's default branch, so the GitHub AP
 | `--json` | Output upload details as JSON. |
 | `--purge` | Delete gh-share workflow runs, artifacts, and staging branches instead of uploading. |
 
-`--purge` asks for confirmation before removing all completed runs of the embedded gh-share workflow in the target repository. The associated artifacts and logs are removed with the runs, and branches used by those runs are deleted except for the repository's default branch and branches containing `.gh-share-persist`. Artifact URLs from the deleted runs will no longer work.
+`--purge` asks for confirmation before removing all completed runs of the embedded gh-share workflow in the target repository. The associated artifacts and logs are removed with the runs, and branches used by those runs are deleted except for the repository's default branch and branches containing `.gh-share/persist`. Artifact URLs from the deleted runs will no longer work.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,17 @@ Everything gh-share writes to the staging branch lives under `.gh-share/`, apart
   payload-ref                   # the workflow's only trigger path
   persist                       # present when --persist was used
   payloads/<timestamp>/         # the uploaded payload
+  artifacts/<artifact id>.json  # what a given artifact URL was made from
 ```
+
+With `--persist`, the artifact record makes an artifact URL resolvable back to its source. Take the artifact ID from the end of the URL and read the matching record:
+
+```bash
+$ gh api "repos/OWNER/REPO/contents/.gh-share/artifacts/456.json?ref=gh-share-staging" \
+    -H 'Accept: application/vnd.github.raw'
+```
+
+The record names the payload directory on the branch, so the shared file or directory can be recovered even after the artifact itself has expired under the retention policy.
 
 ## How it works
 
@@ -71,7 +81,7 @@ flowchart TD
     H --> I[Find artifact and print URL]
     I --> J{Persist requested or enabled?}
     J -->|No| K[Delete staging branch]
-    J -->|Yes| L[Keep staging branch]
+    J -->|Yes| L[Record artifact and keep staging branch]
 ```
 
 The process is:
@@ -82,7 +92,8 @@ The process is:
 4. Add `.gh-share/payload-ref` and the embedded `.github/workflows/upload-gh-share-payload.yml` workflow, then create one commit containing all of them.
 5. Update the staging branch to that commit. The push triggers the workflow because `.gh-share/payload-ref` changed.
 6. Poll GitHub Actions until the workflow completes and resolve the artifact URL.
-7. Delete the staging branch, unless persistence was requested or the branch already contains the persistence marker.
+7. When the staging branch is kept, write `.gh-share/artifacts/<artifact id>.json` recording which input the artifact URL was produced from.
+8. Delete the staging branch, unless persistence was requested or the branch already contains the persistence marker.
 
 ### Why this is tricky
 
@@ -92,7 +103,7 @@ The extension uses the Git Database API directly to create blobs, trees, commits
 
 The workflow reads `.gh-share/payload-ref` to find the timestamped payload directory and determine whether the input was a file or directory. It then uploads that directory with `actions/upload-artifact`.
 
-Only `.gh-share/payload-ref` triggers the workflow. Every share rewrites it with a new timestamp, so listing the payload directory as a trigger path as well would be redundant.
+Only `.gh-share/payload-ref` triggers the workflow. That is what makes the artifact record possible: the record is written under `.gh-share/artifacts/`, so committing it does not start a second upload run for the same payload.
 
 The staging branch is based on the repository's default branch, so the GitHub API can build a valid commit without cloning or modifying the local repository.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The primary use case is sharing a single-page HTML file. The command also suppor
 
 The command displays progress while it creates the staging branch, creates the commit, waits for the workflow, and removes or keeps the branch. The final output includes links to the staging branch, commit, workflow run, and artifact.
 
-For a file, the artifact contains the file under `.gh-share/payloads/<timestamp>/`. For a directory, the directory contents are uploaded as one artifact.
+The payload is committed to the staging branch under `.gh-share/payloads/<timestamp>/`. That directory is the root of the upload, so the artifact holds its contents without the prefix. A file is uploaded unarchived and downloads as the file itself; a directory is uploaded as one zipped artifact.
 
 ## Staging branch layout
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,17 @@ import (
 const (
 	defaultBranch = "gh-share-staging"
 	workflowFile  = "upload-gh-share-payload.yml"
+
+	metaDir        = ".gh-share"
+	payloadRefPath = metaDir + "/payload-ref"
+	payloadsDir    = metaDir + "/payloads"
+	persistPath    = metaDir + "/persist"
+	workflowPath   = ".github/workflows/" + workflowFile
+
+	// Staging branches created before the .gh-share/ layout carry the marker at
+	// the repository root. Reading it keeps those branches from being treated as
+	// unmarked and deleted on the next share or purge.
+	legacyPersistPath = ".gh-share-persist"
 )
 
 var shareRepo, shareBranch string
@@ -241,9 +252,12 @@ func share(ctx context.Context, input string) error {
 	if info.IsDir() {
 		kind = "dir"
 	}
-	files[".gh-share-payload-ref"] = []byte(ts + " " + kind + " " + filepath.Base(filepath.Clean(input)) + "\n")
-	if sharePersist && !marker {
-		files[".gh-share-persist"] = []byte("\n")
+	files[payloadRefPath] = []byte(ts + " " + kind + " " + filepath.Base(filepath.Clean(input)) + "\n")
+	if sharePersist {
+		// Written unconditionally so a branch still marked by the pre-.gh-share/
+		// path picks up the current one. Rewriting identical content reuses the
+		// existing blob, so the commit carries no change for this path.
+		files[persistPath] = []byte("\n")
 	}
 
 	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(colorable.NewColorableStderr()))
@@ -404,7 +418,7 @@ func payloadFiles(input string, dir bool, ts string) (map[string][]byte, error) 
 		if err != nil {
 			return nil, fmt.Errorf("read input: %w", err)
 		}
-		files[filepath.ToSlash(filepath.Join("gh-share-payload", ts, filepath.Base(input)))] = data
+		files[filepath.ToSlash(filepath.Join(payloadsDir, ts, filepath.Base(input)))] = data
 		return files, nil
 	}
 	rootDir, err := os.OpenRoot(filepath.Clean(input))
@@ -423,7 +437,7 @@ func payloadFiles(input string, dir bool, ts string) (map[string][]byte, error) 
 		if err != nil {
 			return err
 		}
-		files[filepath.ToSlash(filepath.Join("gh-share-payload", ts, path))] = data
+		files[filepath.ToSlash(filepath.Join(payloadsDir, ts, path))] = data
 		return nil
 	})
 	if err != nil {
@@ -436,7 +450,20 @@ func payloadFiles(input string, dir bool, ts string) (map[string][]byte, error) 
 }
 
 func hasPersistMarker(ctx context.Context, c *github.Client, owner, repo, branch string) (bool, error) {
-	_, _, _, err := c.Repositories.GetContents(ctx, owner, repo, ".gh-share-persist", &github.RepositoryContentGetOptions{Ref: branch})
+	for _, path := range []string{persistPath, legacyPersistPath} {
+		found, err := branchContains(ctx, c, owner, repo, branch, path)
+		if err != nil {
+			return false, fmt.Errorf("check persist marker: %w", err)
+		}
+		if found {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func branchContains(ctx context.Context, c *github.Client, owner, repo, branch, path string) (bool, error) {
+	_, _, _, err := c.Repositories.GetContents(ctx, owner, repo, path, &github.RepositoryContentGetOptions{Ref: branch})
 	if err == nil {
 		return true, nil
 	}
@@ -444,7 +471,7 @@ func hasPersistMarker(ctx context.Context, c *github.Client, owner, repo, branch
 	if errors.As(err, &e) && (e.Response.StatusCode == 404 || e.Response.StatusCode == 409) {
 		return false, nil
 	}
-	return false, fmt.Errorf("check persist marker: %w", err)
+	return false, err
 }
 
 func commitPayload(ctx context.Context, c *github.Client, owner, repo, branch string, files map[string][]byte, progress func(string)) (string, error) {
@@ -472,7 +499,7 @@ func commitPayload(ctx context.Context, c *github.Client, owner, repo, branch st
 	if err != nil {
 		return "", fmt.Errorf("get staging commit: %w", err)
 	}
-	files[".github/workflows/upload-gh-share-payload.yml"] = uploadWorkflow
+	files[workflowPath] = uploadWorkflow
 	progress("Committing")
 	tree, err := createTree(ctx, c, owner, repo, ref.GetObject().GetSHA(), files)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ const (
 	metaDir        = ".gh-share"
 	payloadRefPath = metaDir + "/payload-ref"
 	payloadsDir    = metaDir + "/payloads"
+	artifactsDir   = metaDir + "/artifacts"
 	persistPath    = metaDir + "/persist"
 	workflowPath   = ".github/workflows/" + workflowFile
 
@@ -266,7 +267,7 @@ func share(ctx context.Context, input string) error {
 	s.Start()
 	defer s.Stop()
 
-	sha, err := commitPayload(ctx, c, owner, repo, shareBranch, files, func(message string) {
+	sha, err := commitPayload(ctx, c, owner, repo, shareBranch, "Share payload", files, func(message string) {
 		s.Suffix = " " + message + " (" + target + ")"
 	})
 	if err != nil {
@@ -284,9 +285,28 @@ func share(ctx context.Context, input string) error {
 	s.Suffix = " Workflow completed: " + runURL
 
 	s.Suffix = " Checking artifact: " + runURL
-	url, err := artifactURL(ctx, c, owner, repo, run.GetID())
+	artifact, err := findArtifact(ctx, c, owner, repo, run.GetID())
 	if err != nil {
 		return err
+	}
+	url := artifactURL(owner, repo, run.GetID(), artifact.GetID())
+	if keep {
+		s.Suffix = " Recording artifact: " + target
+		record := artifactRecord{
+			ArtifactURL: url,
+			ArtifactID:  artifact.GetID(),
+			RunID:       run.GetID(),
+			Commit:      sha,
+			PayloadDir:  payloadsDir + "/" + ts,
+			Input:       filepath.Base(filepath.Clean(input)),
+			InputType:   kind,
+			CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		}
+		if err := recordArtifact(ctx, c, owner, repo, shareBranch, record); err != nil {
+			// The upload already succeeded, so the URL must survive the error or
+			// the user loses the only thing this command exists to produce.
+			return fmt.Errorf("%w (artifact URL: %s)", err, url)
+		}
 	}
 	if shareOpen {
 		if err := openURL(url); err != nil {
@@ -474,7 +494,7 @@ func branchContains(ctx context.Context, c *github.Client, owner, repo, branch, 
 	return false, err
 }
 
-func commitPayload(ctx context.Context, c *github.Client, owner, repo, branch string, files map[string][]byte, progress func(string)) (string, error) {
+func commitPayload(ctx context.Context, c *github.Client, owner, repo, branch, message string, files map[string][]byte, progress func(string)) (string, error) {
 	ref, _, err := c.Git.GetRef(ctx, owner, repo, "heads/"+branch)
 	if err != nil {
 		var e *github.ErrorResponse
@@ -505,7 +525,7 @@ func commitPayload(ctx context.Context, c *github.Client, owner, repo, branch st
 	if err != nil {
 		return "", err
 	}
-	commit, _, err := c.Git.CreateCommit(ctx, owner, repo, github.Commit{Message: new("Share payload"), Tree: tree, Parents: []*github.Commit{baseCommit}}, nil)
+	commit, _, err := c.Git.CreateCommit(ctx, owner, repo, github.Commit{Message: new(message), Tree: tree, Parents: []*github.Commit{baseCommit}}, nil)
 	if err != nil {
 		return "", fmt.Errorf("create commit: %w", err)
 	}
@@ -615,15 +635,50 @@ func waitForRun(ctx context.Context, c *github.Client, owner, repo, sha string, 
 	}
 }
 
-func artifactURL(ctx context.Context, c *github.Client, owner, repo string, runID int64) (string, error) {
+func findArtifact(ctx context.Context, c *github.Client, owner, repo string, runID int64) (*github.Artifact, error) {
 	list, _, err := c.Actions.ListWorkflowRunArtifacts(ctx, owner, repo, runID, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if len(list.Artifacts) == 0 {
-		return "", errors.New("workflow completed without an artifact")
+		return nil, errors.New("workflow completed without an artifact")
 	}
-	return fmt.Sprintf("https://github.com/%s/%s/actions/runs/%d/artifacts/%d", owner, repo, runID, list.Artifacts[0].GetID()), nil
+	return list.Artifacts[0], nil
+}
+
+func artifactURL(owner, repo string, runID, artifactID int64) string {
+	return fmt.Sprintf("https://github.com/%s/%s/actions/runs/%d/artifacts/%d", owner, repo, runID, artifactID)
+}
+
+type artifactRecord struct {
+	ArtifactURL string `json:"artifact_url"`
+	ArtifactID  int64  `json:"artifact_id"`
+	RunID       int64  `json:"run_id"`
+	Commit      string `json:"commit"`
+	PayloadDir  string `json:"payload_dir"`
+	Input       string `json:"input"`
+	InputType   string `json:"input_type"`
+	CreatedAt   string `json:"created_at"`
+}
+
+func artifactRecordPath(artifactID int64) string {
+	return fmt.Sprintf("%s/%d.json", artifactsDir, artifactID)
+}
+
+// recordArtifact writes the record outside the workflow trigger path, so the
+// commit it creates does not start a second upload run for the same payload.
+// Keying the file by artifact ID keeps the lookup a single API call even after
+// --purge has removed the workflow run the URL points at.
+func recordArtifact(ctx context.Context, c *github.Client, owner, repo, branch string, record artifactRecord) error {
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode artifact record: %w", err)
+	}
+	files := map[string][]byte{artifactRecordPath(record.ArtifactID): append(data, '\n')}
+	if _, err := commitPayload(ctx, c, owner, repo, branch, "Record shared artifact", files, func(string) {}); err != nil {
+		return fmt.Errorf("record shared artifact: %w", err)
+	}
+	return nil
 }
 
 func openURL(url string) error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-github/v79/github"
 	"github.com/k1LoW/go-github-client/v79/factory"
 )
 
@@ -50,7 +52,7 @@ func TestGitHubAPIEndToEnd(t *testing.T) {
 	}
 	files[payloadRefPath] = []byte(ts + " file report.html\n")
 
-	sha, err := commitPayload(ctx, c, owner, repo, branch, files, func(string) {})
+	sha, err := commitPayload(ctx, c, owner, repo, branch, "Share payload", files, func(string) {})
 	if err != nil {
 		t.Fatalf("commit payload: %v", err)
 	}
@@ -74,19 +76,67 @@ func TestGitHubAPIEndToEnd(t *testing.T) {
 		t.Fatalf("workflow conclusion = %q, want success", run.GetConclusion())
 	}
 
-	artifact, err := artifactURL(ctx, c, owner, repo, run.GetID())
+	artifact, err := findArtifact(ctx, c, owner, repo, run.GetID())
 	if err != nil {
-		t.Fatalf("get artifact URL: %v", err)
+		t.Fatalf("find artifact: %v", err)
 	}
-	if !strings.Contains(artifact, fmt.Sprintf("/runs/%d/artifacts/", run.GetID())) {
-		t.Fatalf("artifact URL = %q, want run ID %d", artifact, run.GetID())
+	if artifact.GetName() != "report.html" {
+		t.Fatalf("artifact name = %q, want report.html", artifact.GetName())
 	}
-	artifacts, _, err := c.Actions.ListWorkflowRunArtifacts(ctx, owner, repo, run.GetID(), nil)
+	url := artifactURL(owner, repo, run.GetID(), artifact.GetID())
+	if !strings.Contains(url, fmt.Sprintf("/runs/%d/artifacts/%d", run.GetID(), artifact.GetID())) {
+		t.Fatalf("artifact URL = %q, want run %d and artifact %d", url, run.GetID(), artifact.GetID())
+	}
+
+	record := artifactRecord{
+		ArtifactURL: url,
+		ArtifactID:  artifact.GetID(),
+		RunID:       run.GetID(),
+		Commit:      sha,
+		PayloadDir:  payloadsDir + "/" + ts,
+		Input:       "report.html",
+		InputType:   "file",
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := recordArtifact(ctx, c, owner, repo, branch, record); err != nil {
+		t.Fatalf("record artifact: %v", err)
+	}
+
+	content, _, _, err := c.Repositories.GetContents(ctx, owner, repo, artifactRecordPath(artifact.GetID()), &github.RepositoryContentGetOptions{Ref: branch})
 	if err != nil {
-		t.Fatalf("list artifacts: %v", err)
+		t.Fatalf("read artifact record: %v", err)
 	}
-	if len(artifacts.Artifacts) != 1 || artifacts.Artifacts[0].GetName() != "report.html" {
-		t.Fatalf("artifact name = %#v, want report.html", artifacts.Artifacts)
+	raw, err := content.GetContent()
+	if err != nil {
+		t.Fatalf("decode artifact record: %v", err)
+	}
+	var stored artifactRecord
+	if err := json.Unmarshal([]byte(raw), &stored); err != nil {
+		t.Fatalf("unmarshal artifact record: %v", err)
+	}
+	if stored.ArtifactURL != url || stored.PayloadDir != record.PayloadDir || stored.Input != "report.html" {
+		t.Fatalf("artifact record = %#v, want URL %q and payload dir %q", stored, url, record.PayloadDir)
+	}
+
+	// The record commit must not start a second upload run, otherwise every
+	// share would duplicate its artifact.
+	recordRef, _, err := c.Git.GetRef(ctx, owner, repo, "heads/"+branch)
+	if err != nil {
+		t.Fatalf("get staging branch after record: %v", err)
+	}
+	recordSHA := recordRef.GetObject().GetSHA()
+	if recordSHA == sha {
+		t.Fatal("record did not create a commit")
+	}
+	time.Sleep(30 * time.Second)
+	runs, _, err := c.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflowFile, &github.ListWorkflowRunsOptions{Branch: branch, ListOptions: github.ListOptions{PerPage: 20}})
+	if err != nil {
+		t.Fatalf("list workflow runs after record: %v", err)
+	}
+	for _, r := range runs.WorkflowRuns {
+		if r.GetHeadSHA() == recordSHA {
+			t.Fatalf("record commit %s triggered workflow run %d", recordSHA, r.GetID())
+		}
 	}
 }
 
@@ -184,13 +234,34 @@ func TestConfirmPurge(t *testing.T) {
 	}
 }
 
+func TestArtifactURL(t *testing.T) {
+	t.Parallel()
+
+	got := artifactURL("k1LoW", "gh-share", 123, 456)
+	want := "https://github.com/k1LoW/gh-share/actions/runs/123/artifacts/456"
+	if got != want {
+		t.Errorf("artifactURL() = %q, want %q", got, want)
+	}
+}
+
+func TestArtifactRecordPath(t *testing.T) {
+	t.Parallel()
+
+	got := artifactRecordPath(456)
+	want := ".gh-share/artifacts/456.json"
+	if got != want {
+		t.Errorf("artifactRecordPath() = %q, want %q", got, want)
+	}
+}
+
 func TestWorkflowMatchesLayout(t *testing.T) {
 	t.Parallel()
 
 	workflow := string(uploadWorkflow)
 
 	// The workflow triggers on the payload ref alone. If the Go constants and
-	// the embedded workflow drift apart, a share silently stops starting runs.
+	// the embedded workflow drift apart, a share either never starts a run or
+	// the artifact record commit starts a redundant one.
 	if !strings.Contains(workflow, "- '"+payloadRefPath+"'") {
 		t.Errorf("workflow does not trigger on %q:\n%s", payloadRefPath, workflow)
 	}
@@ -200,6 +271,10 @@ func TestWorkflowMatchesLayout(t *testing.T) {
 	if !strings.Contains(workflow, payloadsDir+"/${{ env.PAYLOAD_DIR }}/") {
 		t.Errorf("workflow does not upload from %q:\n%s", payloadsDir, workflow)
 	}
+	if strings.Contains(workflow, artifactsDir) {
+		t.Errorf("workflow references %q, so artifact records would trigger or be uploaded:\n%s", artifactsDir, workflow)
+	}
+
 	// Payloads live under a hidden directory, so upload-artifact must be told to
 	// keep hidden files or a shared directory silently loses its dotfiles.
 	if !strings.Contains(workflow, "include-hidden-files: true") {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -48,7 +48,7 @@ func TestGitHubAPIEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create payload: %v", err)
 	}
-	files[".gh-share-payload-ref"] = []byte(ts + " file report.html\n")
+	files[payloadRefPath] = []byte(ts + " file report.html\n")
 
 	sha, err := commitPayload(ctx, c, owner, repo, branch, files, func(string) {})
 	if err != nil {
@@ -104,7 +104,7 @@ func TestPayloadFilesFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantPath := "gh-share-payload/20260827-120000/report.html"
+	wantPath := ".gh-share/payloads/20260827-120000/report.html"
 	if string(files[wantPath]) != "<h1>Report</h1>" {
 		t.Fatalf("payloadFiles() = %#v, want %q at %q", files, "<h1>Report</h1>", wantPath)
 	}
@@ -127,7 +127,7 @@ func TestPayloadFilesDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantPath := "gh-share-payload/20260827-120000/nested/report.html"
+	wantPath := ".gh-share/payloads/20260827-120000/nested/report.html"
 	if string(files[wantPath]) != "<h1>Report</h1>" {
 		t.Fatalf("payloadFiles() = %#v, want %q at %q", files, "<h1>Report</h1>", wantPath)
 	}
@@ -181,5 +181,28 @@ func TestConfirmPurge(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Purge canceled.") {
 		t.Fatalf("cancellation output = %q", out.String())
+	}
+}
+
+func TestWorkflowMatchesLayout(t *testing.T) {
+	t.Parallel()
+
+	workflow := string(uploadWorkflow)
+
+	// The workflow triggers on the payload ref alone. If the Go constants and
+	// the embedded workflow drift apart, a share silently stops starting runs.
+	if !strings.Contains(workflow, "- '"+payloadRefPath+"'") {
+		t.Errorf("workflow does not trigger on %q:\n%s", payloadRefPath, workflow)
+	}
+	if !strings.Contains(workflow, "read -r PAYLOAD_DIR PAYLOAD_TYPE PAYLOAD_NAME < "+payloadRefPath) {
+		t.Errorf("workflow does not read %q:\n%s", payloadRefPath, workflow)
+	}
+	if !strings.Contains(workflow, payloadsDir+"/${{ env.PAYLOAD_DIR }}/") {
+		t.Errorf("workflow does not upload from %q:\n%s", payloadsDir, workflow)
+	}
+	// Payloads live under a hidden directory, so upload-artifact must be told to
+	// keep hidden files or a shared directory silently loses its dotfiles.
+	if !strings.Contains(workflow, "include-hidden-files: true") {
+		t.Errorf("workflow does not set include-hidden-files:\n%s", workflow)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,6 +91,14 @@ func TestGitHubAPIEndToEnd(t *testing.T) {
 		t.Fatalf("artifact URL = %q, want run %d and artifact %d", url, run.GetID(), artifact.GetID())
 	}
 
+	// A file artifact is stored unarchived, so the download is the file itself.
+	// Checking the bytes is what catches the payload being uploaded from the
+	// wrong directory or arriving empty, which the artifact name alone hides.
+	body := downloadArtifact(ctx, t, c, owner, repo, artifact.GetID())
+	if string(body) != "<h1>E2E</h1>" {
+		t.Fatalf("artifact content = %q, want %q", body, "<h1>E2E</h1>")
+	}
+
 	record := artifactRecord{
 		ArtifactURL: url,
 		ArtifactID:  artifact.GetID(),
@@ -138,6 +149,124 @@ func TestGitHubAPIEndToEnd(t *testing.T) {
 			t.Fatalf("record commit %s triggered workflow run %d", recordSHA, r.GetID())
 		}
 	}
+	if len(runs.WorkflowRuns) != 1 {
+		t.Fatalf("branch produced %d workflow runs, want 1", len(runs.WorkflowRuns))
+	}
+}
+
+func TestGitHubAPIEndToEndDirectory(t *testing.T) {
+	if os.Getenv("GH_SHARE_E2E") == "" {
+		t.Skip("set GH_SHARE_E2E=1 to run the GitHub API end-to-end test")
+	}
+
+	const repository = "k1LoW/gh-share"
+	owner, repo, ok := strings.Cut(repository, "/")
+	if !ok || owner == "" || repo == "" {
+		t.Fatalf("invalid repository: %s", repository)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+	c, err := factory.NewGithubClient()
+	if err != nil {
+		t.Fatalf("create GitHub client: %v", err)
+	}
+
+	branch := fmt.Sprintf("gh-share-e2e-dir-%d", time.Now().UnixNano())
+	previousBranch := shareBranch
+	shareBranch = branch
+	t.Cleanup(func() {
+		shareBranch = previousBranch
+		_, _ = c.Git.DeleteRef(context.Background(), owner, repo, "heads/"+branch)
+	})
+
+	input := filepath.Join(t.TempDir(), "site")
+	if err := os.Mkdir(input, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"index.html": "<h1>E2E</h1>",
+		".nojekyll":  "",
+	} {
+		if err := os.WriteFile(filepath.Join(input, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ts := time.Now().UTC().Format("20060102-150405")
+	files, err := payloadFiles(input, true, ts)
+	if err != nil {
+		t.Fatalf("create payload: %v", err)
+	}
+	files[payloadRefPath] = []byte(ts + " dir site\n")
+
+	sha, err := commitPayload(ctx, c, owner, repo, branch, "Share payload", files, func(string) {})
+	if err != nil {
+		t.Fatalf("commit payload: %v", err)
+	}
+
+	run, err := waitForRun(ctx, c, owner, repo, sha, func(string) {})
+	if err != nil {
+		t.Fatalf("wait for workflow: %v", err)
+	}
+	artifact, err := findArtifact(ctx, c, owner, repo, run.GetID())
+	if err != nil {
+		t.Fatalf("find artifact: %v", err)
+	}
+
+	// A directory artifact is zipped. Payloads live under a hidden directory, so
+	// this is where a regression in hidden-file handling shows up: .nojekyll is
+	// dropped from the archive rather than failing the upload.
+	body := downloadArtifact(ctx, t, c, owner, repo, artifact.GetID())
+	archive, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		t.Fatalf("open artifact archive (%d bytes): %v", len(body), err)
+	}
+	entries := map[string]string{}
+	for _, f := range archive.File {
+		r, err := f.Open()
+		if err != nil {
+			t.Fatalf("open %s in artifact: %v", f.Name, err)
+		}
+		content, err := io.ReadAll(r)
+		r.Close()
+		if err != nil {
+			t.Fatalf("read %s in artifact: %v", f.Name, err)
+		}
+		entries[f.Name] = string(content)
+	}
+	if got, ok := entries["index.html"]; !ok || got != "<h1>E2E</h1>" {
+		t.Fatalf("artifact entries = %#v, want index.html with the payload", entries)
+	}
+	if _, ok := entries[".nojekyll"]; !ok {
+		t.Fatalf("artifact entries = %#v, want .nojekyll to survive the upload", entries)
+	}
+}
+
+func downloadArtifact(ctx context.Context, t *testing.T, c *github.Client, owner, repo string, artifactID int64) []byte {
+	t.Helper()
+
+	u, _, err := c.Actions.DownloadArtifact(ctx, owner, repo, artifactID, 10)
+	if err != nil {
+		t.Fatalf("resolve artifact download URL: %v", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		t.Fatalf("build artifact download request: %v", err)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("download artifact: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("download artifact: status %d", res.StatusCode)
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read artifact: %v", err)
+	}
+	return body
 }
 
 func TestPayloadFilesFile(t *testing.T) {

--- a/cmd/upload-gh-share-payload.yml
+++ b/cmd/upload-gh-share-payload.yml
@@ -3,8 +3,7 @@ name: "gh-share: Upload payload"
 on:
   push:
     paths:
-      - 'gh-share-payload/**'
-      - '.gh-share-payload-ref'
+      - '.gh-share/payload-ref'
 
 jobs:
   upload:
@@ -15,7 +14,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Read payload ref
         run: |
-          read -r PAYLOAD_DIR PAYLOAD_TYPE PAYLOAD_NAME < .gh-share-payload-ref
+          read -r PAYLOAD_DIR PAYLOAD_TYPE PAYLOAD_NAME < .gh-share/payload-ref
           echo "PAYLOAD_DIR=$PAYLOAD_DIR" >> "$GITHUB_ENV"
           echo "PAYLOAD_TYPE=$PAYLOAD_TYPE" >> "$GITHUB_ENV"
           echo "PAYLOAD_NAME=$PAYLOAD_NAME" >> "$GITHUB_ENV"
@@ -24,12 +23,14 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.PAYLOAD_NAME }}
-          path: gh-share-payload/${{ env.PAYLOAD_DIR }}/
+          path: .gh-share/payloads/${{ env.PAYLOAD_DIR }}/
           archive: false
+          include-hidden-files: true
       - name: Upload (dir)
         if: env.PAYLOAD_TYPE == 'dir'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.PAYLOAD_NAME }}
-          path: gh-share-payload/${{ env.PAYLOAD_DIR }}/
+          path: .gh-share/payloads/${{ env.PAYLOAD_DIR }}/
           archive: true
+          include-hidden-files: true


### PR DESCRIPTION
## Summary

An artifact URL says nothing about what produced it, so a persisted staging branch cannot answer which file was shared at a given URL. That mapping is derivable today only by resolving the workflow run's head SHA and reading the payload ref at that commit, which stops working once `--purge` deletes the run. The payload on the branch outlives the artifact anyway, so the branch is the right place to keep the answer.

Recording it needs somewhere on the branch the upload workflow ignores. The trigger is now `.gh-share/payload-ref` alone. Every share rewrites that file with a new timestamp, so matching the payload directory as well was already redundant, and dropping it frees the rest of `.gh-share/` for files that must not start a run.

**Breaking.** Everything gh-share writes to the staging branch moves under `.gh-share/`. Branches from earlier versions keep working: `.gh-share-persist` is still read when deciding whether a branch is persisted, and `--persist` now rewrites the marker at its new path so those branches migrate on their next share. Leftover `gh-share-payload/` directories stay behind, since removing them needs tree-entry deletion the current `buildTree` does not do, and staging branches are disposable by default.

Worth a look from a reviewer: putting the record inside the payload directory instead would have been simpler, but `archive: false` accepts only a single file, so it would break every single-file share.

## Changes

- move the payload, payload ref, and persistence marker under `.gh-share/`, and trigger the workflow on `.gh-share/payload-ref` alone
- write `.gh-share/artifacts/<artifact id>.json` when the branch is kept, keyed so a lookup stays one API call after `--purge` removes the run
- keep the artifact URL in the error when recording fails, since the upload has already succeeded by then
- set `include-hidden-files`, which the hidden payload directory requires and which also stops directory shares from dropping their own dotfiles
- tie the Go path constants to the embedded workflow in a test, because drift between them either stops runs starting or makes the record commit start a redundant one