### PR TITLE
feat: reshare a payload already on the staging branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ $ gh share --open pr123.html
 # Keep the staging branch after the upload
 $ gh share --persist pr123.html
 
+# Share a payload already on the staging branch again, by artifact URL or ID
+$ gh share --reshare 456
+
 # Output upload details as JSON
 $ gh share --json pr123.html
 
@@ -62,7 +65,14 @@ $ gh api "repos/OWNER/REPO/contents/.gh-share/artifacts/456.json?ref=gh-share-st
     -H 'Accept: application/vnd.github.raw'
 ```
 
-The record names the payload directory on the branch, so the shared file or directory can be recovered even after the artifact itself has expired under the retention policy.
+The record names the payload directory on the branch, so the shared file or directory can be recovered even after the artifact itself has expired under the retention policy. `--reshare` does that recovery for you: it reads the record, uploads the payload from the branch again, and prints a fresh artifact URL. The original file never has to be on your machine.
+
+```bash
+$ gh share --reshare https://github.com/OWNER/REPO/actions/runs/123/artifacts/456
+$ gh share --reshare 456
+```
+
+A reshare records its own artifact as well, with `reshared_from` pointing at the artifact it was made from. The URL it prints can therefore be reshared in turn, without limit. The payload directory is reused rather than copied, so only the records accumulate.
 
 ## How it works
 
@@ -71,6 +81,7 @@ The record names the payload directory on the branch, so the shared file or dire
 ```mermaid
 flowchart TD
     A[gh share file or directory] --> B[Resolve target repository with gh]
+    A2[gh share --reshare artifact URL or ID] --> B
     B --> C{Staging branch exists?}
     C -->|No| D[Create branch from default branch]
     C -->|Yes| E[Use staging branch]
@@ -89,7 +100,7 @@ The process is:
 1. Resolve the target repository with `gh repo view`.
 2. Check whether the staging branch exists. If it does not, create it from the repository's default branch.
 3. Create Git blobs for the payload and build the required tree structure through the GitHub Git Database API.
-4. Add `.gh-share/payload-ref` and the embedded `.github/workflows/upload-gh-share-payload.yml` workflow, then create one commit containing all of them.
+4. Add `.gh-share/payload-ref` and the embedded `.github/workflows/upload-gh-share-payload.yml` workflow, then create one commit containing all of them. The payload ref opens with a share ID that changes on every share.
 5. Update the staging branch to that commit. The push triggers the workflow because `.gh-share/payload-ref` changed.
 6. Poll GitHub Actions until the workflow completes and resolve the artifact URL.
 7. When the staging branch is kept, write `.gh-share/artifacts/<artifact id>.json` recording which input the artifact URL was produced from.
@@ -105,6 +116,8 @@ The workflow reads `.gh-share/payload-ref` to find the timestamped payload direc
 
 Only `.gh-share/payload-ref` triggers the workflow. That is what makes the artifact record possible: the record is written under `.gh-share/artifacts/`, so committing it does not start a second upload run for the same payload.
 
+It also means a reshare has to change that one file, and resharing a payload changes nothing about it. The payload ref therefore leads with a share ID, separate from the payload directory it names, so that rewriting the ID alone re-triggers the workflow while the payload stays where it is. The ID carries random bits rather than a finer timestamp, because a clock with microsecond resolution can hand two back-to-back reshares the same value, and an unchanged payload ref starts no run at all.
+
 The staging branch is based on the repository's default branch, so the GitHub API can build a valid commit without cloning or modifying the local repository.
 
 ## Command-line options
@@ -115,8 +128,11 @@ The staging branch is based on the repository's default branch, so the GitHub AP
 | `--branch` | Staging branch name. Defaults to `gh-share-staging`. |
 | `--open` | Open the artifact URL in the browser after the upload completes. |
 | `--persist` | Keep the staging branch after the upload. |
+| `--reshare` | Re-upload the payload behind an artifact URL or ID instead of a local path. |
 | `--json` | Output upload details as JSON. |
 | `--purge` | Delete gh-share workflow runs, artifacts, and staging branches instead of uploading. |
+
+`--reshare` takes an artifact URL or the bare ID at the end of it, reads `.gh-share/artifacts/<artifact id>.json` from the staging branch, and uploads the payload that record names again. Only artifacts shared with a kept staging branch have a record, so `--reshare` needs `--persist` to have been used on the original share. The staging branch is always kept afterwards, since deleting it would discard the payload that was just shared and end the chain of reshares.
 
 `--purge` asks for confirmation before removing all completed runs of the embedded gh-share workflow in the target repository. The associated artifacts and logs are removed with the runs, and branches used by those runs are deleted except for the repository's default branch and branches containing `.gh-share/persist`. The `.gh-share-persist` marker written before the `.gh-share/` layout still counts as one, so branches persisted by an earlier version are kept as well. Artifact URLs from the deleted runs will no longer work.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,7 +64,7 @@ func Execute() {
 
 func newShareCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "share <file|dir|artifact>",
+		Use:   "share <file|dir>",
 		Short: "Share a single HTML file or other files and directories through GitHub Actions artifacts",
 		Long: `Share a single HTML file or other files and directories using GitHub's built-in Git and Actions APIs.
 
@@ -773,8 +773,9 @@ func payloadRef(shareID, dir, kind, name string) []byte {
 // waiting out its timeout on a workflow run that never starts.
 func shareID() string {
 	buf := make([]byte, 8)
-	// crypto/rand.Read panics rather than reporting failure, so there is no error
-	// worth surfacing from a value that only has to differ from the last one.
+	// crypto/rand.Read never returns an error and always fills buf entirely; it
+	// crashes the program instead. There is no partially filled buf to guard
+	// against, so no error reaches this caller.
 	_, _ = rand.Read(buf)
 	return time.Now().UTC().Format("20060102-150405") + "-" + hex.EncodeToString(buf)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,8 +13,10 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -43,7 +47,7 @@ const (
 )
 
 var shareRepo, shareBranch string
-var shareOpen, sharePersist, shareJSON, sharePurge bool
+var shareOpen, sharePersist, shareJSON, sharePurge, shareReshare bool
 
 var rootCmd = func() *cobra.Command {
 	cmd := newShareCommand()
@@ -60,24 +64,34 @@ func Execute() {
 
 func newShareCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "share <file|dir>",
+		Use:   "share <file|dir|artifact>",
 		Short: "Share a single HTML file or other files and directories through GitHub Actions artifacts",
 		Long: `Share a single HTML file or other files and directories using GitHub's built-in Git and Actions APIs.
 
 gh-share creates a temporary staging branch, commits the payload and an upload workflow, waits for GitHub Actions to upload the artifact, and removes the branch when finished.
 
+Use --reshare with an artifact URL or ID to upload a payload already stored on the staging branch again. Artifacts expire while the staging branch does not, so this hands out a fresh artifact URL without the payload ever leaving the repository.
+
 Use --purge without an input path to delete gh-share workflow runs, their artifacts and logs, and associated staging branches.`,
 		Args: func(cmd *cobra.Command, args []string) error {
-			if sharePurge {
+			// --reshare takes an argument even alongside --purge, so that the two
+			// report as a conflicting pair rather than as a stray argument.
+			if sharePurge && !shareReshare {
 				return cobra.NoArgs(cmd, args)
 			}
 			return cobra.ExactArgs(1)(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if sharePurge {
+			switch {
+			case sharePurge && shareReshare:
+				return errors.New("--purge and --reshare cannot be combined")
+			case sharePurge:
 				return purge(cmd.Context(), cmd.InOrStdin(), cmd.ErrOrStderr())
+			case shareReshare:
+				return reshare(cmd.Context(), args[0])
+			default:
+				return share(cmd.Context(), args[0])
 			}
-			return share(cmd.Context(), args[0])
 		},
 	}
 	cmd.Flags().StringVar(&shareRepo, "repo", "", "Target repository (owner/repo; defaults to the current repository)")
@@ -85,6 +99,7 @@ Use --purge without an input path to delete gh-share workflow runs, their artifa
 	cmd.Flags().BoolVar(&shareOpen, "open", false, "Open the artifact URL in the browser")
 	cmd.Flags().BoolVar(&sharePersist, "persist", false, "Keep the staging branch after upload")
 	cmd.Flags().BoolVar(&shareJSON, "json", false, "Output upload details as JSON")
+	cmd.Flags().BoolVar(&shareReshare, "reshare", false, "Re-upload the payload behind an artifact URL or ID kept on the staging branch")
 	cmd.Flags().BoolVar(&sharePurge, "purge", false, "Delete gh-share workflow runs, artifacts, and staging branches")
 	return cmd
 }
@@ -245,7 +260,7 @@ func share(ctx context.Context, input string) error {
 		kind = "dir"
 	}
 	name := filepath.Base(filepath.Clean(input))
-	files[payloadRefPath] = []byte(ts + " " + kind + " " + name + "\n")
+	files[payloadRefPath] = payloadRef(shareID(), ts, kind, name)
 	if sharePersist {
 		// Written unconditionally so a branch still marked by the pre-.gh-share/
 		// path picks up the current one. Rewriting identical content reuses the
@@ -258,6 +273,51 @@ func share(ctx context.Context, input string) error {
 		name:       name,
 		kind:       kind,
 		keep:       marker || sharePersist,
+		action:     "uploaded",
+	})
+}
+
+// reshare uploads a payload that is already on the staging branch, so the input
+// never leaves the repository. Because it also records the new artifact, the URL
+// it prints can itself be reshared, without limit.
+func reshare(ctx context.Context, ref string) error {
+	artifactID, err := parseArtifactRef(ref)
+	if err != nil {
+		return err
+	}
+	c, owner, repo, err := prepare(ctx)
+	if err != nil {
+		return err
+	}
+	record, err := readArtifactRecord(ctx, c, owner, repo, shareBranch, artifactID)
+	if err != nil {
+		return err
+	}
+	// Checked before committing, because a missing payload directory would only
+	// surface as a failed workflow run that uploaded nothing.
+	found, err := branchContains(ctx, c, owner, repo, shareBranch, record.PayloadDir)
+	if err != nil {
+		return fmt.Errorf("check payload directory: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("payload directory %s is no longer on branch %s", record.PayloadDir, shareBranch)
+	}
+	files := map[string][]byte{
+		payloadRefPath: payloadRef(shareID(), path.Base(record.PayloadDir), record.InputType, record.Input),
+	}
+	if sharePersist {
+		files[persistPath] = []byte("\n")
+	}
+	return upload(ctx, c, owner, repo, payloadPlan{
+		files:      files,
+		payloadDir: record.PayloadDir,
+		name:       record.Input,
+		kind:       record.InputType,
+		// Deleting the branch would throw away the only copy of what was just
+		// shared, and end the chain of reshares at this artifact.
+		keep:         true,
+		action:       "re-uploaded",
+		resharedFrom: artifactID,
 	})
 }
 
@@ -277,13 +337,15 @@ func prepare(ctx context.Context) (*github.Client, string, string, error) {
 }
 
 // payloadPlan is what a share commits to the staging branch and what the result
-// describes, so that uploading does not depend on how the payload was assembled.
+// describes, so a fresh share and a reshare differ only in how the plan is built.
 type payloadPlan struct {
-	files      map[string][]byte
-	payloadDir string
-	name       string
-	kind       string
-	keep       bool
+	files        map[string][]byte
+	payloadDir   string
+	name         string
+	kind         string
+	keep         bool
+	action       string
+	resharedFrom int64
 }
 
 func upload(ctx context.Context, c *github.Client, owner, repo string, plan payloadPlan) error {
@@ -321,14 +383,15 @@ func upload(ctx context.Context, c *github.Client, owner, repo string, plan payl
 	if plan.keep {
 		s.Suffix = " Recording artifact: " + target
 		record := artifactRecord{
-			ArtifactURL: url,
-			ArtifactID:  artifact.GetID(),
-			RunID:       run.GetID(),
-			Commit:      sha,
-			PayloadDir:  plan.payloadDir,
-			Input:       plan.name,
-			InputType:   plan.kind,
-			CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+			ArtifactURL:  url,
+			ArtifactID:   artifact.GetID(),
+			RunID:        run.GetID(),
+			Commit:       sha,
+			PayloadDir:   plan.payloadDir,
+			Input:        plan.name,
+			InputType:    plan.kind,
+			ResharedFrom: plan.resharedFrom,
+			CreatedAt:    time.Now().UTC().Format(time.RFC3339),
 		}
 		if err := recordArtifact(ctx, c, owner, repo, shareBranch, record); err != nil {
 			// The upload already succeeded, so the URL must survive the error or
@@ -354,9 +417,9 @@ func upload(ctx context.Context, c *github.Client, owner, repo string, plan payl
 		branchStatus = "kept"
 	}
 	branchURL := fmt.Sprintf("https://github.com/%s/%s/tree/%s", owner, repo, shareBranch)
-	uploadMessage := fmt.Sprintf("Successfully uploaded %s.", plan.name)
+	uploadMessage := fmt.Sprintf("Successfully %s %s.", plan.action, plan.name)
 	if plan.kind == "dir" {
-		uploadMessage = fmt.Sprintf("Successfully uploaded directory: %s", plan.name)
+		uploadMessage = fmt.Sprintf("Successfully %s directory: %s", plan.action, plan.name)
 	}
 	result := shareResult{
 		Input:         plan.name,
@@ -685,11 +748,77 @@ type artifactRecord struct {
 	PayloadDir  string `json:"payload_dir"`
 	Input       string `json:"input"`
 	InputType   string `json:"input_type"`
-	CreatedAt   string `json:"created_at"`
+	// ResharedFrom is the artifact this one was made from, so a chain of reshares
+	// of one payload can be walked back to the share that first uploaded it.
+	ResharedFrom int64  `json:"reshared_from,omitempty"`
+	CreatedAt    string `json:"created_at"`
 }
 
 func artifactRecordPath(artifactID int64) string {
 	return fmt.Sprintf("%s/%d.json", artifactsDir, artifactID)
+}
+
+// payloadRef renders the line the upload workflow reads. The share ID leads the
+// line and changes on every share, so re-sharing an unchanged payload still
+// rewrites the one file the workflow's push paths filter watches.
+func payloadRef(shareID, dir, kind, name string) []byte {
+	return []byte(shareID + " " + dir + " " + kind + " " + name + "\n")
+}
+
+// shareID ends in random bits rather than a finer timestamp because the clock
+// resolution is only microseconds on some platforms. Two reshares of one payload
+// that share an ID render an identical payload ref, which leaves the command
+// waiting out its timeout on a workflow run that never starts.
+func shareID() string {
+	buf := make([]byte, 8)
+	// crypto/rand.Read panics rather than reporting failure, so there is no error
+	// worth surfacing from a value that only has to differ from the last one.
+	_, _ = rand.Read(buf)
+	return time.Now().UTC().Format("20060102-150405") + "-" + hex.EncodeToString(buf)
+}
+
+// parseArtifactRef accepts what a previous share printed, which is the artifact
+// URL, as well as the bare ID at the end of it.
+func parseArtifactRef(ref string) (int64, error) {
+	trimmed := strings.TrimSuffix(strings.TrimSpace(ref), "/")
+	if i := strings.LastIndex(trimmed, "/"); i >= 0 {
+		trimmed = trimmed[i+1:]
+	}
+	id, err := strconv.ParseInt(trimmed, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, fmt.Errorf("invalid artifact reference %q; pass an artifact URL or ID", ref)
+	}
+	return id, nil
+}
+
+func readArtifactRecord(ctx context.Context, c *github.Client, owner, repo, branch string, artifactID int64) (*artifactRecord, error) {
+	recordPath := artifactRecordPath(artifactID)
+	content, _, _, err := c.Repositories.GetContents(ctx, owner, repo, recordPath, &github.RepositoryContentGetOptions{Ref: branch})
+	if err != nil {
+		var e *github.ErrorResponse
+		if errors.As(err, &e) && (e.Response.StatusCode == 404 || e.Response.StatusCode == 409) {
+			return nil, fmt.Errorf("no record for artifact %d on branch %s; only artifacts shared with a kept staging branch can be reshared", artifactID, branch)
+		}
+		return nil, fmt.Errorf("read artifact record: %w", err)
+	}
+	if content == nil {
+		return nil, fmt.Errorf("%s is not a file", recordPath)
+	}
+	raw, err := content.GetContent()
+	if err != nil {
+		return nil, fmt.Errorf("decode artifact record %s: %w", recordPath, err)
+	}
+	var record artifactRecord
+	if err := json.Unmarshal([]byte(raw), &record); err != nil {
+		return nil, fmt.Errorf("parse artifact record %s: %w", recordPath, err)
+	}
+	if record.PayloadDir == "" || record.Input == "" {
+		return nil, fmt.Errorf("artifact record %s does not name the payload it was made from", recordPath)
+	}
+	if record.InputType != "file" && record.InputType != "dir" {
+		return nil, fmt.Errorf("artifact record %s has input type %q, want file or dir", recordPath, record.InputType)
+	}
+	return &record, nil
 }
 
 // recordArtifact writes the record outside the workflow trigger path, so the

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -227,23 +227,14 @@ func share(ctx context.Context, input string) error {
 	if err != nil {
 		return fmt.Errorf("stat input: %w", err)
 	}
-	if shareBranch == "" || strings.ContainsAny(shareBranch, " ~^:?*[\\\\") {
-		return errors.New("invalid branch name")
-	}
-	owner, repo, err := repository(ctx, shareRepo)
+	c, owner, repo, err := prepare(ctx)
 	if err != nil {
 		return err
-	}
-	c, err := factory.NewGithubClient()
-	if err != nil {
-		return fmt.Errorf("create GitHub client: %w", err)
 	}
 	marker, err := hasPersistMarker(ctx, c, owner, repo, shareBranch)
 	if err != nil {
 		return err
 	}
-	keep := marker || sharePersist
-	target := fmt.Sprintf("%s/%s@%s", owner, repo, shareBranch)
 	ts := time.Now().UTC().Format("20060102-150405")
 	files, err := payloadFiles(input, info.IsDir(), ts)
 	if err != nil {
@@ -253,13 +244,50 @@ func share(ctx context.Context, input string) error {
 	if info.IsDir() {
 		kind = "dir"
 	}
-	files[payloadRefPath] = []byte(ts + " " + kind + " " + filepath.Base(filepath.Clean(input)) + "\n")
+	name := filepath.Base(filepath.Clean(input))
+	files[payloadRefPath] = []byte(ts + " " + kind + " " + name + "\n")
 	if sharePersist {
 		// Written unconditionally so a branch still marked by the pre-.gh-share/
 		// path picks up the current one. Rewriting identical content reuses the
 		// existing blob, so the commit carries no change for this path.
 		files[persistPath] = []byte("\n")
 	}
+	return upload(ctx, c, owner, repo, payloadPlan{
+		files:      files,
+		payloadDir: payloadsDir + "/" + ts,
+		name:       name,
+		kind:       kind,
+		keep:       marker || sharePersist,
+	})
+}
+
+func prepare(ctx context.Context) (*github.Client, string, string, error) {
+	if shareBranch == "" || strings.ContainsAny(shareBranch, " ~^:?*[\\\\") {
+		return nil, "", "", errors.New("invalid branch name")
+	}
+	owner, repo, err := repository(ctx, shareRepo)
+	if err != nil {
+		return nil, "", "", err
+	}
+	c, err := factory.NewGithubClient()
+	if err != nil {
+		return nil, "", "", fmt.Errorf("create GitHub client: %w", err)
+	}
+	return c, owner, repo, nil
+}
+
+// payloadPlan is what a share commits to the staging branch and what the result
+// describes, so that uploading does not depend on how the payload was assembled.
+type payloadPlan struct {
+	files      map[string][]byte
+	payloadDir string
+	name       string
+	kind       string
+	keep       bool
+}
+
+func upload(ctx context.Context, c *github.Client, owner, repo string, plan payloadPlan) error {
+	target := fmt.Sprintf("%s/%s@%s", owner, repo, shareBranch)
 
 	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(colorable.NewColorableStderr()))
 	_ = s.Color("fgCyan")
@@ -267,7 +295,7 @@ func share(ctx context.Context, input string) error {
 	s.Start()
 	defer s.Stop()
 
-	sha, err := commitPayload(ctx, c, owner, repo, shareBranch, "Share payload", files, func(message string) {
+	sha, err := commitPayload(ctx, c, owner, repo, shareBranch, "Share payload", plan.files, func(message string) {
 		s.Suffix = " " + message + " (" + target + ")"
 	})
 	if err != nil {
@@ -290,16 +318,16 @@ func share(ctx context.Context, input string) error {
 		return err
 	}
 	url := artifactURL(owner, repo, run.GetID(), artifact.GetID())
-	if keep {
+	if plan.keep {
 		s.Suffix = " Recording artifact: " + target
 		record := artifactRecord{
 			ArtifactURL: url,
 			ArtifactID:  artifact.GetID(),
 			RunID:       run.GetID(),
 			Commit:      sha,
-			PayloadDir:  payloadsDir + "/" + ts,
-			Input:       filepath.Base(filepath.Clean(input)),
-			InputType:   kind,
+			PayloadDir:  plan.payloadDir,
+			Input:       plan.name,
+			InputType:   plan.kind,
 			CreatedAt:   time.Now().UTC().Format(time.RFC3339),
 		}
 		if err := recordArtifact(ctx, c, owner, repo, shareBranch, record); err != nil {
@@ -313,7 +341,7 @@ func share(ctx context.Context, input string) error {
 			return fmt.Errorf("open artifact URL: %w", err)
 		}
 	}
-	if !keep {
+	if !plan.keep {
 		s.Suffix = " Deleting branch: " + target
 		if _, err := c.Git.DeleteRef(ctx, owner, repo, "heads/"+shareBranch); err != nil {
 			return fmt.Errorf("delete staging branch: %w", err)
@@ -322,21 +350,20 @@ func share(ctx context.Context, input string) error {
 		s.Suffix = " Keeping branch: " + target
 	}
 	branchStatus := "deleted"
-	if keep {
+	if plan.keep {
 		branchStatus = "kept"
 	}
 	branchURL := fmt.Sprintf("https://github.com/%s/%s/tree/%s", owner, repo, shareBranch)
-	inputName := filepath.Base(filepath.Clean(input))
-	uploadMessage := fmt.Sprintf("Successfully uploaded %s.", inputName)
-	if info.IsDir() {
-		uploadMessage = fmt.Sprintf("Successfully uploaded directory: %s", inputName)
+	uploadMessage := fmt.Sprintf("Successfully uploaded %s.", plan.name)
+	if plan.kind == "dir" {
+		uploadMessage = fmt.Sprintf("Successfully uploaded directory: %s", plan.name)
 	}
 	result := shareResult{
-		Input:         inputName,
-		InputType:     kind,
+		Input:         plan.name,
+		InputType:     plan.kind,
 		Repository:    fmt.Sprintf("https://github.com/%s/%s", owner, repo),
 		Branch:        branchURL,
-		BranchDeleted: !keep,
+		BranchDeleted: !plan.keep,
 		Commit:        commitURL,
 		Workflow:      runURL,
 		Artifact:      url,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -305,9 +305,11 @@ func reshare(ctx context.Context, ref string) error {
 	files := map[string][]byte{
 		payloadRefPath: payloadRef(shareID(), path.Base(record.PayloadDir), record.InputType, record.Input),
 	}
-	if sharePersist {
-		files[persistPath] = []byte("\n")
-	}
+	// Written whether or not --persist was passed, because the branch is kept
+	// either way. A record only ever exists on an already marked branch, but
+	// relying on that would leave the marker and the forced keep below to be
+	// read against each other across two functions.
+	files[persistPath] = []byte("\n")
 	return upload(ctx, c, owner, repo, payloadPlan{
 		files:      files,
 		payloadDir: record.PayloadDir,
@@ -778,10 +780,15 @@ func shareID() string {
 }
 
 // parseArtifactRef accepts what a previous share printed, which is the artifact
-// URL, as well as the bare ID at the end of it.
+// URL, as well as the bare ID at the end of it. A path is required to name the
+// artifact, so that a run URL is rejected here rather than resolving to the run
+// ID and failing later as a record that does not exist.
 func parseArtifactRef(ref string) (int64, error) {
 	trimmed := strings.TrimSuffix(strings.TrimSpace(ref), "/")
 	if i := strings.LastIndex(trimmed, "/"); i >= 0 {
+		if path.Base(trimmed[:i]) != "artifacts" {
+			return 0, fmt.Errorf("invalid artifact reference %q; pass an artifact URL ending in /artifacts/<id>, or the ID alone", ref)
+		}
 		trimmed = trimmed[i+1:]
 	}
 	id, err := strconv.ParseInt(trimmed, 10, 64)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -534,7 +534,11 @@ func TestParseArtifactRef(t *testing.T) {
 		{name: "empty", ref: "", wantErr: true},
 		{name: "zero", ref: "0", wantErr: true},
 		{name: "negative", ref: "-1", wantErr: true},
-		{name: "run URL without an artifact", ref: "https://github.com/o/r/actions/runs/123", want: 123},
+		// A run URL ends in a run ID, which names a different resource. Resolving
+		// it would report the run ID back as an artifact with no record.
+		{name: "run URL", ref: "https://github.com/o/r/actions/runs/123", wantErr: true},
+		{name: "API artifact URL", ref: "https://api.github.com/repos/o/r/actions/artifacts/456", want: 456},
+		{name: "artifacts path without an ID", ref: "https://github.com/o/r/actions/runs/123/artifacts", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -53,7 +54,7 @@ func TestGitHubAPIEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create payload: %v", err)
 	}
-	files[payloadRefPath] = []byte(ts + " file report.html\n")
+	files[payloadRefPath] = payloadRef(shareID(), ts, "file", "report.html")
 
 	sha, err := commitPayload(ctx, c, owner, repo, branch, "Share payload", files, func(string) {})
 	if err != nil {
@@ -152,6 +153,67 @@ func TestGitHubAPIEndToEnd(t *testing.T) {
 	if len(runs.WorkflowRuns) != 1 {
 		t.Fatalf("branch produced %d workflow runs, want 1", len(runs.WorkflowRuns))
 	}
+
+	// Resharing rewrites nothing but the share ID in the payload ref. The payload
+	// stays where it is, so this is what proves that the share ID alone re-triggers
+	// the workflow and that the artifact is reproduced from the branch.
+	reshareFiles := map[string][]byte{
+		payloadRefPath: payloadRef(shareID(), path.Base(stored.PayloadDir), stored.InputType, stored.Input),
+	}
+	reshareSHA, err := commitPayload(ctx, c, owner, repo, branch, "Share payload", reshareFiles, func(string) {})
+	if err != nil {
+		t.Fatalf("commit reshare payload ref: %v", err)
+	}
+	reshareRun, err := waitForRun(ctx, c, owner, repo, reshareSHA, func(string) {})
+	if err != nil {
+		t.Fatalf("wait for reshare workflow: %v", err)
+	}
+	reshareArtifact, err := findArtifact(ctx, c, owner, repo, reshareRun.GetID())
+	if err != nil {
+		t.Fatalf("find reshare artifact: %v", err)
+	}
+	if reshareArtifact.GetID() == artifact.GetID() {
+		t.Fatal("reshare produced the same artifact as the original share")
+	}
+	if body := downloadArtifact(ctx, t, c, owner, repo, reshareArtifact.GetID()); string(body) != "<h1>E2E</h1>" {
+		t.Fatalf("reshared artifact content = %q, want %q", body, "<h1>E2E</h1>")
+	}
+
+	// The reshare records itself too, which is what lets its own artifact URL be
+	// reshared in turn.
+	reshareRecord := artifactRecord{
+		ArtifactURL:  artifactURL(owner, repo, reshareRun.GetID(), reshareArtifact.GetID()),
+		ArtifactID:   reshareArtifact.GetID(),
+		RunID:        reshareRun.GetID(),
+		Commit:       reshareSHA,
+		PayloadDir:   stored.PayloadDir,
+		Input:        stored.Input,
+		InputType:    stored.InputType,
+		ResharedFrom: artifact.GetID(),
+		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := recordArtifact(ctx, c, owner, repo, branch, reshareRecord); err != nil {
+		t.Fatalf("record reshared artifact: %v", err)
+	}
+	chained, err := readArtifactRecord(ctx, c, owner, repo, branch, reshareArtifact.GetID())
+	if err != nil {
+		t.Fatalf("read reshared artifact record: %v", err)
+	}
+	if chained.PayloadDir != record.PayloadDir {
+		t.Errorf("reshared record payload dir = %q, want the original %q", chained.PayloadDir, record.PayloadDir)
+	}
+	if chained.ResharedFrom != artifact.GetID() {
+		t.Errorf("reshared record reshared_from = %d, want %d", chained.ResharedFrom, artifact.GetID())
+	}
+
+	// One payload directory regardless of how many times it was shared.
+	_, payloads, _, err := c.Repositories.GetContents(ctx, owner, repo, payloadsDir, &github.RepositoryContentGetOptions{Ref: branch})
+	if err != nil {
+		t.Fatalf("list payload directories: %v", err)
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("%s holds %d entries, want 1 after a reshare", payloadsDir, len(payloads))
+	}
 }
 
 func TestGitHubAPIEndToEndDirectory(t *testing.T) {
@@ -198,7 +260,7 @@ func TestGitHubAPIEndToEndDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create payload: %v", err)
 	}
-	files[payloadRefPath] = []byte(ts + " dir site\n")
+	files[payloadRefPath] = payloadRef(shareID(), ts, "dir", "site")
 
 	sha, err := commitPayload(ctx, c, owner, repo, branch, "Share payload", files, func(string) {})
 	if err != nil {
@@ -394,7 +456,7 @@ func TestWorkflowMatchesLayout(t *testing.T) {
 	if !strings.Contains(workflow, "- '"+payloadRefPath+"'") {
 		t.Errorf("workflow does not trigger on %q:\n%s", payloadRefPath, workflow)
 	}
-	if !strings.Contains(workflow, "read -r PAYLOAD_DIR PAYLOAD_TYPE PAYLOAD_NAME < "+payloadRefPath) {
+	if !strings.Contains(workflow, "read -r SHARE_ID PAYLOAD_DIR PAYLOAD_TYPE PAYLOAD_NAME < "+payloadRefPath) {
 		t.Errorf("workflow does not read %q:\n%s", payloadRefPath, workflow)
 	}
 	if !strings.Contains(workflow, payloadsDir+"/${{ env.PAYLOAD_DIR }}/") {
@@ -408,5 +470,107 @@ func TestWorkflowMatchesLayout(t *testing.T) {
 	// keep hidden files or a shared directory silently loses its dotfiles.
 	if !strings.Contains(workflow, "include-hidden-files: true") {
 		t.Errorf("workflow does not set include-hidden-files:\n%s", workflow)
+	}
+}
+
+func TestPayloadRef(t *testing.T) {
+	t.Parallel()
+
+	got := string(payloadRef("20260828-120000-4a2f7d6bf6698163", "20260101-090000", "file", "report.html"))
+	want := "20260828-120000-4a2f7d6bf6698163 20260101-090000 file report.html\n"
+	if got != want {
+		t.Errorf("payloadRef() = %q, want %q", got, want)
+	}
+
+	// The share ID is the only thing that makes a reshare of an unchanged payload
+	// modify the file the workflow's push paths filter watches.
+	other := string(payloadRef("20260828-120000-9c1e05b3a7f2d846", "20260101-090000", "file", "report.html"))
+	if got == other {
+		t.Errorf("payloadRef() is identical for two share IDs: %q", got)
+	}
+}
+
+func TestPayloadRefKeepsNamesWithSpaces(t *testing.T) {
+	t.Parallel()
+
+	// The workflow reads the line with `read -r`, so the name must stay last for
+	// the shell to hand it over whole.
+	got := string(payloadRef("20260828-120000-4a2f7d6bf6698163", "20260101-090000", "file", "my report.html"))
+	if !strings.HasSuffix(got, " my report.html\n") {
+		t.Errorf("payloadRef() = %q, want the name to end the line", got)
+	}
+}
+
+func TestShareIDIsUniquePerCall(t *testing.T) {
+	t.Parallel()
+
+	// Timestamps alone collide here, because the clock resolution is only
+	// microseconds on some platforms, and a colliding share ID leaves a reshare
+	// waiting out its timeout on a workflow run that never starts.
+	seen := map[string]struct{}{}
+	for range 100 {
+		id := shareID()
+		if _, ok := seen[id]; ok {
+			t.Fatalf("shareID() returned %q twice", id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+func TestParseArtifactRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ref     string
+		want    int64
+		wantErr bool
+	}{
+		{name: "artifact URL", ref: "https://github.com/o/r/actions/runs/123/artifacts/456", want: 456},
+		{name: "artifact URL with trailing slash", ref: "https://github.com/o/r/actions/runs/123/artifacts/456/", want: 456},
+		{name: "bare ID", ref: "456", want: 456},
+		{name: "surrounding whitespace", ref: "  456\n", want: 456},
+		{name: "not a number", ref: "not-a-url", wantErr: true},
+		{name: "empty", ref: "", wantErr: true},
+		{name: "zero", ref: "0", wantErr: true},
+		{name: "negative", ref: "-1", wantErr: true},
+		{name: "run URL without an artifact", ref: "https://github.com/o/r/actions/runs/123", want: 123},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseArtifactRef(tt.ref)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseArtifactRef(%q) = %d, want an error", tt.ref, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseArtifactRef(%q): %v", tt.ref, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseArtifactRef(%q) = %d, want %d", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestArtifactRecordOmitsResharedFromOnFirstShare(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(artifactRecord{ArtifactID: 456, PayloadDir: payloadsDir + "/20260101-090000"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "reshared_from") {
+		t.Errorf("artifactRecord = %s, want no reshared_from for a first share", data)
+	}
+	data, err = json.Marshal(artifactRecord{ArtifactID: 789, ResharedFrom: 456})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"reshared_from": 456`) && !strings.Contains(string(data), `"reshared_from":456`) {
+		t.Errorf("artifactRecord = %s, want reshared_from 456", data)
 	}
 }

--- a/cmd/upload-gh-share-payload.yml
+++ b/cmd/upload-gh-share-payload.yml
@@ -14,7 +14,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Read payload ref
         run: |
-          read -r PAYLOAD_DIR PAYLOAD_TYPE PAYLOAD_NAME < .gh-share/payload-ref
+          # SHARE_ID is unused here. It changes on every share so that re-sharing
+          # an unchanged payload still rewrites this file and passes the push
+          # paths filter above.
+          read -r SHARE_ID PAYLOAD_DIR PAYLOAD_TYPE PAYLOAD_NAME < .gh-share/payload-ref
           echo "PAYLOAD_DIR=$PAYLOAD_DIR" >> "$GITHUB_ENV"
           echo "PAYLOAD_TYPE=$PAYLOAD_TYPE" >> "$GITHUB_ENV"
           echo "PAYLOAD_NAME=$PAYLOAD_NAME" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

An artifact expires under the retention policy; the staging branch does not. A persisted branch therefore ends up holding a payload whose only URL is dead, and `.gh-share/artifacts/<artifact id>.json` names that payload but nothing can act on it. Sharing again meant still having the original file on hand. `--reshare` takes an artifact URL or the bare ID at the end of it, reads the record, and uploads the payload straight from the branch.

The obstacle is that the workflow triggers on `.gh-share/payload-ref` alone, and resharing a payload changes nothing about that file, so the commit carries no diff on the trigger path and no run starts. The payload ref now leads with a share ID kept separate from the payload directory it names, so rewriting the ID alone re-triggers the workflow while the payload stays put. I confirmed the premise against the API rather than assuming it: a commit with an identical tree pushed to the trigger path started no run.

Worth a look from a reviewer: the alternative was copying the payload into a fresh timestamped directory, which needs no format change and costs no blob uploads since the existing tree entry can be reused, but leaves a duplicate directory behind on every reshare. Keeping one payload directory is what makes a reshare of a reshare cheap, and that chain is the point of `reshared_from`.

The share ID carries random bits rather than a finer timestamp because the clock resolution is only microseconds on some platforms. That was not a guess either: the nanosecond-formatted version failed `TestShareIDIsUniquePerCall` on the first run.

## Changes

- read the payload ref as four fields so the leading share ID re-triggers the workflow without moving the payload
- add `--reshare`, which resolves an artifact URL or ID through the record on the branch instead of a local path, and refuses to commit when the payload directory it names is gone
- always keep the branch after a reshare, whatever `--persist` says, since deleting it discards the only copy of what was just shared and ends the chain
- record `reshared_from` so a chain of reshares can be walked back to the share that first uploaded the payload
- extend the end-to-end test with a reshare round that downloads the second artifact and asserts the payload directory count, which is what proves the share ID alone is load-bearing