### PR TITLE
fix: print the artifact URL to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ The primary use case is sharing a single-page HTML file. The command also suppor
 
 The command displays progress while it creates the staging branch, creates the commit, waits for the workflow, and removes or keeps the branch. The final output includes links to the staging branch, commit, workflow run, and artifact.
 
+Progress and the summary go to stderr, and the artifact URL is written to stdout on its own line, so it can be piped without `--json`:
+
+```bash
+$ gh share pr123.html | pbcopy
+```
+
 The payload is committed to the staging branch under `.gh-share/payloads/<timestamp>/`. That directory is the root of the upload, so the artifact holds its contents without the prefix. A file is uploaded unarchived and downloads as the file itself; a directory is uploaded as one zipped artifact.
 
 ## Staging branch layout

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -434,7 +434,7 @@ func upload(ctx context.Context, c *github.Client, owner, repo string, plan payl
 		Artifact:      url,
 	}
 	if !shareJSON {
-		s.FinalMSG = "\n" + uploadMessage + "\n\n" + formatSummary(branchURL, branchStatus, commitURL, runURL) + formatArtifactURL(url)
+		s.FinalMSG = "\n" + uploadMessage + "\n\n" + formatSummary(branchURL, branchStatus, commitURL, runURL) + artifactURLLabel()
 	}
 	s.Stop()
 	if shareJSON {
@@ -443,7 +443,12 @@ func upload(ctx context.Context, c *github.Client, owner, repo string, plan payl
 		if err := encoder.Encode(result); err != nil {
 			return fmt.Errorf("encode JSON output: %w", err)
 		}
+		return nil
 	}
+	// The artifact URL is the only value worth piping, so it goes to stdout on
+	// its own while the progress output and its label stay on stderr.
+	fmt.Fprintln(os.Stdout, url)
+	fmt.Fprintln(os.Stderr)
 	return nil
 }
 
@@ -490,10 +495,8 @@ func formatSummary(branchURL, branchStatus, commitURL, runURL string) string {
 	return summary.String()
 }
 
-func formatArtifactURL(url string) string {
-	labelStyle := color.New(color.FgCyan, color.Bold)
-	valueStyle := color.New(color.FgWhite)
-	return fmt.Sprintf("%s\n%s\n\n", labelStyle.Sprint("Artifact URL:"), valueStyle.Sprint(url))
+func artifactURLLabel() string {
+	return color.New(color.FgCyan, color.Bold).Sprint("Artifact URL:") + "\n"
 }
 
 func repository(ctx context.Context, selector string) (string, string, error) {


### PR DESCRIPTION
## Summary

The artifact URL is the one value the command exists to produce, but it reached the terminal through the spinner's final message, whose writer is stderr. `gh share pr123.html | pbcopy` therefore piped nothing, and the only way to capture the URL was `--json`, which means parsing a document to recover a single string that has no structure to it.

Only the URL moves to stdout. Progress, the summary frame, and the `Artifact URL:` label stay on stderr, so redirecting one stream keeps the human output readable while the other carries one bare line. Splitting the label from the value is what makes the piped line usable without a consumer stripping a prefix off it, and it also matches how `--purge` already keeps its prompts off stdout.

Worth a look from a reviewer: the value loses its white styling. The color package decides on escapes from whether stdout is a terminal, so keeping the style would have been safe, but a URL that now only ever travels alone on its own stream has nothing left to be emphasized against.

`--json` output is untouched, so anything already consuming it sees no change.

## Changes

- print the artifact URL to stdout after the spinner stops, leaving the rest of the human output on stderr
- reduce `formatArtifactURL` to `artifactURLLabel`, since the value it used to format is no longer written to the same stream as its label
- document the stream split in the README, next to the existing description of the final output