### PR TITLE
refactor!: drop the pre-.gh-share/ persistence marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The staging branch is based on the repository's default branch, so the GitHub AP
 
 `--reshare` takes an artifact URL or the bare ID at the end of it, reads `.gh-share/artifacts/<artifact id>.json` from the staging branch, and uploads the payload that record names again. Only artifacts shared with a kept staging branch have a record, so `--reshare` needs `--persist` to have been used on the original share. The staging branch is always kept afterwards, since deleting it would discard the payload that was just shared and end the chain of reshares.
 
-`--purge` asks for confirmation before removing all completed runs of the embedded gh-share workflow in the target repository. The associated artifacts and logs are removed with the runs, and branches used by those runs are deleted except for the repository's default branch and branches containing `.gh-share/persist`. The `.gh-share-persist` marker written before the `.gh-share/` layout still counts as one, so branches persisted by an earlier version are kept as well. Artifact URLs from the deleted runs will no longer work.
+`--purge` asks for confirmation before removing all completed runs of the embedded gh-share workflow in the target repository. The associated artifacts and logs are removed with the runs, and branches used by those runs are deleted except for the repository's default branch and branches containing `.gh-share/persist`. Artifact URLs from the deleted runs will no longer work.
 
 ## Installation
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,11 +39,6 @@ const (
 	artifactsDir   = metaDir + "/artifacts"
 	persistPath    = metaDir + "/persist"
 	workflowPath   = ".github/workflows/" + workflowFile
-
-	// Staging branches created before the .gh-share/ layout carry the marker at
-	// the repository root. Reading it keeps those branches from being treated as
-	// unmarked and deleted on the next share or purge.
-	legacyPersistPath = ".gh-share-persist"
 )
 
 var shareRepo, shareBranch string
@@ -262,9 +257,9 @@ func share(ctx context.Context, input string) error {
 	name := filepath.Base(filepath.Clean(input))
 	files[payloadRefPath] = payloadRef(shareID(), ts, kind, name)
 	if sharePersist {
-		// Written unconditionally so a branch still marked by the pre-.gh-share/
-		// path picks up the current one. Rewriting identical content reuses the
-		// existing blob, so the commit carries no change for this path.
+		// Not gated on the marker already being present. Rewriting identical
+		// content reuses the existing blob, so the commit carries no change for
+		// this path.
 		files[persistPath] = []byte("\n")
 	}
 	return upload(ctx, c, owner, repo, payloadPlan{
@@ -565,16 +560,11 @@ func payloadFiles(input string, dir bool, ts string) (map[string][]byte, error) 
 }
 
 func hasPersistMarker(ctx context.Context, c *github.Client, owner, repo, branch string) (bool, error) {
-	for _, path := range []string{persistPath, legacyPersistPath} {
-		found, err := branchContains(ctx, c, owner, repo, branch, path)
-		if err != nil {
-			return false, fmt.Errorf("check persist marker: %w", err)
-		}
-		if found {
-			return true, nil
-		}
+	found, err := branchContains(ctx, c, owner, repo, branch, persistPath)
+	if err != nil {
+		return false, fmt.Errorf("check persist marker: %w", err)
 	}
-	return false, nil
+	return found, nil
 }
 
 func branchContains(ctx context.Context, c *github.Client, owner, repo, branch, path string) (bool, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -192,7 +192,7 @@ func purge(ctx context.Context, in io.Reader, out io.Writer) error {
 		}
 		persist, err := hasPersistMarker(ctx, c, owner, repo, branch)
 		if err != nil {
-			return fmt.Errorf("check persist marker for staging branch %s: %w", branch, err)
+			return err
 		}
 		if persist {
 			continue

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -615,14 +616,24 @@ func TestHasPersistMarker(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			var gotPath, gotRef string
+			// The handler runs on the server's goroutine, so what it observed is
+			// handed back under a lock rather than through the ordering that the
+			// response happens to impose.
+			var mu sync.Mutex
+			var path, ref string
 			c := stubGitHubClient(t, func(w http.ResponseWriter, r *http.Request) {
-				gotPath, gotRef = r.URL.Path, r.URL.Query().Get("ref")
+				mu.Lock()
+				path, ref = r.URL.Path, r.URL.Query().Get("ref")
+				mu.Unlock()
 				w.WriteHeader(tt.status)
 				_, _ = w.Write([]byte(`{"message":"stub"}`))
 			})
 
 			got, err := hasPersistMarker(context.Background(), c, "k1LoW", "gh-share", "gh-share-staging")
+
+			mu.Lock()
+			gotPath, gotRef := path, ref
+			mu.Unlock()
 
 			// The path and the ref are asserted because a lookup aimed anywhere
 			// else reports an unmarked branch, and an unmarked branch is one that

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -576,5 +578,73 @@ func TestArtifactRecordOmitsResharedFromOnFirstShare(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"reshared_from": 456`) && !strings.Contains(string(data), `"reshared_from":456`) {
 		t.Errorf("artifactRecord = %s, want reshared_from 456", data)
+	}
+}
+
+// stubGitHubClient serves every API call from h, so a test can state what the
+// GitHub contents endpoint answers without reaching the network.
+func stubGitHubClient(t *testing.T, h http.HandlerFunc) *github.Client {
+	t.Helper()
+	server := httptest.NewServer(h)
+	t.Cleanup(server.Close)
+	c := github.NewClient(nil)
+	base, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatalf("parse stub server URL: %v", err)
+	}
+	c.BaseURL = base
+	return c
+}
+
+func TestHasPersistMarker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		status  int
+		want    bool
+		wantErr bool
+	}{
+		{name: "marker present", status: http.StatusOK, want: true},
+		{name: "marker absent", status: http.StatusNotFound},
+		// An empty repository answers 409 for any path, which means the branch
+		// carries no marker rather than that the lookup failed.
+		{name: "empty repository", status: http.StatusConflict},
+		{name: "lookup fails", status: http.StatusInternalServerError, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var gotPath, gotRef string
+			c := stubGitHubClient(t, func(w http.ResponseWriter, r *http.Request) {
+				gotPath, gotRef = r.URL.Path, r.URL.Query().Get("ref")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(`{"message":"stub"}`))
+			})
+
+			got, err := hasPersistMarker(context.Background(), c, "k1LoW", "gh-share", "gh-share-staging")
+
+			// The path and the ref are asserted because a lookup aimed anywhere
+			// else reports an unmarked branch, and an unmarked branch is one that
+			// the next share or --purge deletes.
+			if want := "/repos/k1LoW/gh-share/contents/" + persistPath; gotPath != want {
+				t.Errorf("requested path = %q, want %q", gotPath, want)
+			}
+			if want := "gh-share-staging"; gotRef != want {
+				t.Errorf("requested ref = %q, want %q", gotRef, want)
+			}
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("hasPersistMarker() = %v, want an error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("hasPersistMarker(): %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("hasPersistMarker() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -620,10 +620,10 @@ func TestHasPersistMarker(t *testing.T) {
 			// handed back under a lock rather than through the ordering that the
 			// response happens to impose.
 			var mu sync.Mutex
-			var path, ref string
+			var requestPath, requestRef string
 			c := stubGitHubClient(t, func(w http.ResponseWriter, r *http.Request) {
 				mu.Lock()
-				path, ref = r.URL.Path, r.URL.Query().Get("ref")
+				requestPath, requestRef = r.URL.Path, r.URL.Query().Get("ref")
 				mu.Unlock()
 				w.WriteHeader(tt.status)
 				_, _ = w.Write([]byte(`{"message":"stub"}`))
@@ -632,7 +632,7 @@ func TestHasPersistMarker(t *testing.T) {
 			got, err := hasPersistMarker(context.Background(), c, "k1LoW", "gh-share", "gh-share-staging")
 
 			mu.Lock()
-			gotPath, gotRef := path, ref
+			gotPath, gotRef := requestPath, requestRef
 			mu.Unlock()
 
 			// The path and the ref are asserted because a lookup aimed anywhere

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -582,18 +582,19 @@ func TestArtifactRecordOmitsResharedFromOnFirstShare(t *testing.T) {
 	}
 }
 
-// stubGitHubClient serves every API call from h, so a test can state what the
-// GitHub contents endpoint answers without reaching the network.
+// stubGitHubClient points the client's API and upload endpoints at h, so a
+// test can state what GitHub answers without reaching the network.
 func stubGitHubClient(t *testing.T, h http.HandlerFunc) *github.Client {
 	t.Helper()
 	server := httptest.NewServer(h)
 	t.Cleanup(server.Close)
-	c := github.NewClient(nil)
 	base, err := url.Parse(server.URL + "/")
 	if err != nil {
 		t.Fatalf("parse stub server URL: %v", err)
 	}
+	c := github.NewClient(server.Client())
 	c.BaseURL = base
+	c.UploadURL = base
 	return c
 }
 


### PR DESCRIPTION
## Summary

`.gh-share-persist` has been read alongside `.gh-share/persist` since v0.3.0 moved the staging layout, so that a branch persisted by an earlier version was not mistaken for an unmarked one and deleted on the next share or purge. Two minor releases later the compatibility earns its keep only for a branch that v0.2.x persisted and that has had no share since, because `--persist` rewrites the marker at the current path and migrates the branch on its first share after the upgrade.

Against a window that closes on its own, it costs a contents API call on every share and on every branch a purge inspects, and it puts a second definition of "persisted" into the documentation, where every statement of the rule then has to carry the exception. Removing it is what lets `--help` describe the marker as one path.

**Breaking.** A staging branch marked only at the old path now counts as unmarked, so the next share or `--purge` deletes it. Committing an empty `.gh-share/persist` to such a branch keeps it, since the check is presence alone.

Worth a look from a reviewer: `hasPersistMarker` is now a single `branchContains` call and adds only the error context, so it is thin enough to inline at its two call sites. It stays because the name is what makes `marker || sharePersist` in `share` and the branch loop in `purge` readable without chasing a path constant.

## Changes

- drop `legacyPersistPath` and reduce `hasPersistMarker` to the current path alone
- rewrite the comment on the unconditional `--persist` marker write, whose stated reason was migrating a legacy-marked branch, leaving the blob-reuse reason that still holds
- drop the legacy marker sentence from the README's `--purge` description
